### PR TITLE
fixes make for F4ProtoMatrix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,8 +66,8 @@ libmathicgb_la_SOURCES = src/mathicgb/BjarkeGeobucket2.cpp		\
   src/mathicgb/CFile.cpp src/mathicgb/LogDomain.hpp			\
   src/mathicgb/LogDomain.cpp src/mathicgb/LogDomainSet.hpp \
   src/mathicgb/F4MatrixBuilder2.hpp src/mathicgb/F4MatrixBuilder2.cpp \
-  src/mathicgb/LogDomainSet.cpp src/mathicgb/ProtoMatrix.hpp \
-  src/mathicgb/ProtoMatrix.cpp src/mathicgb/F4MatrixProject.hpp \
+  src/mathicgb/LogDomainSet.cpp src/mathicgb/F4ProtoMatrix.hpp \
+  src/mathicgb/F4ProtoMatrix.cpp src/mathicgb/F4MatrixProject.hpp \
   src/mathicgb/F4MatrixProjection.cpp
 
 # When making a distribution file, Automake knows to include all files


### PR DESCRIPTION
needed to rename "ProtoMatrix" to "F4ProtoMatrix"
